### PR TITLE
Better handling of interrupted exceptions

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 }
 
 qupath {
-    version = "0.6.0"
+    version = "0.7.0"
 }
 
 // Apply QuPath Gradle settings plugin to handle configuration

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 }
 
 qupath {
-    version = "0.7.0"
+    version = "0.6.0"
 }
 
 // Apply QuPath Gradle settings plugin to handle configuration

--- a/src/main/java/qupath/ext/omero/core/pixelapis/PixelApiReader.java
+++ b/src/main/java/qupath/ext/omero/core/pixelapis/PixelApiReader.java
@@ -16,6 +16,9 @@ public interface PixelApiReader extends AutoCloseable {
 
     /**
      * Read a tile of an image.
+     * <p>
+     * This function may return null if the calling thread is interrupted. If any other error occurs, an {@link IOException}
+     * is thrown.
      *
      * @param tileRequest the tile parameters
      * @return the resulting image

--- a/src/main/java/qupath/ext/omero/core/pixelapis/ice/IceReader.java
+++ b/src/main/java/qupath/ext/omero/core/pixelapis/ice/IceReader.java
@@ -153,6 +153,10 @@ class IceReader implements PixelApiReader {
                         tileRequest.getTileHeight()
                 );
             }
+        } catch (InterruptedException e) {
+            logger.debug("Reading tile {} from ICE API interrupted. Interrupting current thread", tileRequest, e);
+            Thread.currentThread().interrupt();
+            return null;
         } catch (Exception e) {
             throw new IOException(e);
         } finally {

--- a/src/main/java/qupath/ext/omero/core/pixelapis/mspixelbuffer/MsPixelBufferReader.java
+++ b/src/main/java/qupath/ext/omero/core/pixelapis/mspixelbuffer/MsPixelBufferReader.java
@@ -24,9 +24,9 @@ import java.awt.image.WritableRaster;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.stream.IntStream;
 
 /**
@@ -80,19 +80,29 @@ class MsPixelBufferReader implements PixelApiReader {
         // OMERO expects resolutions to be specified in reverse order
         int level = numberOfLevels - tileRequest.getLevel() - 1;
 
-        List<BufferedImage> images;
-        try {
-            images = IntStream.range(0, numberOfChannels)
-                    .mapToObj(i -> readTile(
-                            imageID,
-                            i,
-                            level,
-                            tileRequest
-                    ))
-                    .map(CompletableFuture::join)
-                    .toList();
-        } catch (CompletionException e) {
-            throw new IOException(e);
+        List<CompletableFuture<BufferedImage>> imageRequests = IntStream.range(0, numberOfChannels)
+                .mapToObj(i -> readTile(
+                        imageID,
+                        i,
+                        level,
+                        tileRequest
+                ))
+                .toList();
+        List<BufferedImage> images = new ArrayList<>();
+        for (var request: imageRequests) {
+            try {
+                images.add(request.get());
+            } catch (InterruptedException e) {
+                logger.debug(
+                        "Reading tile {} from pixel buffer microservice API interrupted. Interrupting current thread",
+                        tileRequest,
+                        e
+                );
+                Thread.currentThread().interrupt();
+                return null;
+            } catch (Exception e) {
+                throw new IOException(e);
+            }
         }
         logger.debug("Got images {} for {}. Combining them", images, tileRequest);
 

--- a/src/main/java/qupath/ext/omero/core/pixelapis/web/WebReader.java
+++ b/src/main/java/qupath/ext/omero/core/pixelapis/web/WebReader.java
@@ -9,7 +9,6 @@ import qupath.ext.omero.core.pixelapis.PixelApiReader;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Read pixel values using the <a href="https://docs.openmicroscopy.org/omero/latest/developers/json-api.html">OMERO JSON API</a>.
@@ -59,11 +58,11 @@ class WebReader implements PixelApiReader {
                     preferredTileHeight,
                     jpegQuality
             ).get();
-        } catch (InterruptedException | ExecutionException e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-
+        } catch (InterruptedException e) {
+            logger.debug("Reading tile {} from web API interrupted. Interrupting current thread", tileRequest, e);
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (Exception e) {
             throw new IOException(e);
         }
     }


### PR DESCRIPTION
Fix #119 by making pixel APIs return `null` instead of throwing exceptions when the calling thread is interrupted.