### PR TITLE
Select the "Public data" user by default on IDR server

### DIFF
--- a/src/main/java/qupath/ext/omero/gui/browser/Browser.java
+++ b/src/main/java/qupath/ext/omero/gui/browser/Browser.java
@@ -451,7 +451,7 @@ class Browser extends Stage implements AutoCloseable {
             owner.getSelectionModel().select(server.getDefaultGroup().getExperimenters().stream()
                     .filter(e -> !e.equals(server.getConnectedExperimenter()))
                     .findAny()
-                    .orElse(owner.getValue())
+                    .orElse(server.getConnectedExperimenter())
             );
         }
 

--- a/src/main/java/qupath/ext/omero/gui/browser/Browser.java
+++ b/src/main/java/qupath/ext/omero/gui/browser/Browser.java
@@ -449,7 +449,7 @@ class Browser extends Stage implements AutoCloseable {
         // doesn't contain any data, but another user called "Public data" does
         if (client.getApisHandler().getWebServerUri().toString().contains("idr.openmicroscopy.org")) {
             owner.getSelectionModel().select(server.getDefaultGroup().getExperimenters().stream()
-                    .filter(e -> !e.equals(server.getConnectedExperimenter()))
+                    .filter(e -> e.getFullName().equals("Public data"))
                     .findAny()
                     .orElse(server.getConnectedExperimenter())
             );

--- a/src/main/java/qupath/ext/omero/gui/browser/Browser.java
+++ b/src/main/java/qupath/ext/omero/gui/browser/Browser.java
@@ -445,6 +445,15 @@ class Browser extends Stage implements AutoCloseable {
                 return null;
             }
         });
+        // See https://github.com/qupath/qupath-extension-omero/issues/120: the default public user of the IDR server
+        // doesn't contain any data, but another user called "Public data" does
+        if (client.getApisHandler().getWebServerUri().toString().contains("idr.openmicroscopy.org")) {
+            owner.getSelectionModel().select(server.getDefaultGroup().getExperimenters().stream()
+                    .filter(e -> !e.equals(server.getConnectedExperimenter()))
+                    .findAny()
+                    .orElse(owner.getValue())
+            );
+        }
 
         PredicateTextField<RepositoryEntity> predicateTextField = new PredicateTextField<>(RepositoryEntity::getLabel);
         predicateTextField.setPromptText(resources.getString("Browser.ServerBrowser.filterNames"));


### PR DESCRIPTION
Fix #120 by selecting the "Public data" user by default when the browser is open with an unauthenticated connection to https://idr.openmicroscopy.org/webclient